### PR TITLE
Force VSCode UI extensions to be used in UI only

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,9 @@
     },
     "files.trimTrailingWhitespace": true,
     "files.trimFinalNewlines": true,
-    "files.insertFinalNewline": true
+    "files.insertFinalNewline": true,
+    "remote.extensionKind": {
+        "ms-azuretools.vscode-docker": "ui",
+        "ms-vscode-remote.remote-containers": "ui"
+    }
 }


### PR DESCRIPTION
Changelog:
- Add field `remote.extensionKind` to `.vscode/settings.json` to force some extensions to be in UI mode only.


This closes #21.